### PR TITLE
Bumped Minimum Python to 3.8

### DIFF
--- a/.github/workflows/test_and_package_wheel.yml
+++ b/.github/workflows/test_and_package_wheel.yml
@@ -12,15 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-        exclude:
-          # Exclude Python 3.6 - 3.8 on macOS (Apple Silicon incompatible)
-          - os: macos-latest
-            python-version: "3.6"
-          - os: macos-latest
-            python-version: "3.7"
-          - os: macos-latest
-            python-version: "3.8"
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
 
     steps:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # zpickle
 
 <p align="center">
-  <img src="https://img.shields.io/github/workflow/status/dupontcyborg/zpickle/test_and_package_wheel" alt="Build Status"/>
+  <img src="https://img.shields.io/github/actions/workflow/status/dupontcyborg/zpickle/test_and_package_wheel.yml" alt="Build Status"/>
   <img src="https://img.shields.io/pypi/v/zpickle" alt="PyPI Version"/>
   <img src="https://img.shields.io/github/v/release/dupontcyborg/zpickle" alt="GitHub Release"/>
 </p>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,19 +1,60 @@
 [build-system]
 requires = [
-    "setuptools>=45",
+    "setuptools>=61.0.0",
     "wheel",
     "setuptools_scm>=6.2"
 ]
 build-backend = "setuptools.build_meta"
 
+[project]
+name = "zpickle"
+description = "Transparent, drop-in compression for Python's pickle"
+readme = "README.md"
+requires-python = ">=3.8"
+license = {text = "MIT"}
+authors = [
+    {name = "Nicolas Dupont"}
+]
+keywords = ["pickle", "compression", "serialization", "zstd", "brotli", "zlib", "lzma"]
+classifiers = [
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: System :: Archiving :: Compression",
+    "Topic :: Software Development :: Libraries",
+    "Operating System :: OS Independent",
+]
+dependencies = [
+    "compress-utils",
+]
+dynamic = ["version"]
+
+[project.urls]
+"Homepage" = "https://github.com/dupontcyborg/zpickle"
+"Bug Tracker" = "https://github.com/dupontcyborg/zpickle/issues"
+"Documentation" = "https://github.com/dupontcyborg/zpickle#readme"
+"Source Code" = "https://github.com/dupontcyborg/zpickle"
+
 [tool.setuptools_scm]
 version_scheme = "guess-next-dev"
 local_scheme = "no-local-version"
 write_to = "zpickle/_version.py"
+fallback_version = "0.0.0+unknown"
+
+[tool.setuptools]
+packages = ["zpickle"]
+zip-safe = false
 
 [tool.black]
 line-length = 88
-target-version = ['py37', 'py38', 'py39', 'py310', 'py311', 'py312']
+target-version = ['py38', 'py39', 'py310', 'py311', 'py312']
 
 [tool.isort]
 profile = "black"

--- a/setup.py
+++ b/setup.py
@@ -1,56 +1,8 @@
 #!/usr/bin/env python
+"""Compatibility setup.py for Python environments that don't fully support pyproject.toml."""
 
-import os
-from setuptools import setup, find_packages
+from setuptools import setup
 
-# Read the long description from README.md
-with open("README.md", encoding="utf-8") as f:
-    long_description = f.read()
-
-setup(
-    name="zpickle",
-    use_scm_version={
-        "write_to": "zpickle/_version.py",
-        "version_scheme": "guess-next-dev",
-        "local_scheme": "no-local-version",
-        "fallback_version": "0.0.0+unknown",
-    },
-    description="Transparent, drop-in compression for Python's pickle",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    author="Nicolas Dupont",
-    url="https://github.com/dupontcyborg/zpickle",
-    project_urls={
-        "Bug Tracker": "https://github.com/dupontcyborg/zpickle/issues",
-        "Documentation": "https://github.com/dupontcyborg/zpickle#readme",
-        "Source Code": "https://github.com/dupontcyborg/zpickle",
-    },
-    keywords=["pickle", "compression", "serialization", "zstd", "brotli", "zlib", "lzma"],
-    license="MIT",
-    packages=["zpickle"],
-    setup_requires=[
-        "setuptools_scm>=3.4",
-    ],
-    classifiers=[
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "Topic :: System :: Archiving :: Compression",
-        "Topic :: Software Development :: Libraries",
-        "Operating System :: OS Independent",
-    ],
-    python_requires=">=3.6",
-    install_requires=[
-        "compress-utils",
-    ],
-    zip_safe=False,
-)
+if __name__ == "__main__":
+    # All configuration is in pyproject.toml
+    setup()


### PR DESCRIPTION
This PR bumps the minimum Python version for `zpickle` to **3.8**. This was done in order to:

- Avoid needing to add explicit support for Pickle's Protocol 3, which was superseded by [Protocol 4](https://peps.python.org/pep-3154/) in 3.8.
- Address compatibility issues in the CI pipelines
- Allow the migration of package metadata from `setup.py` to `pyproject.toml` 